### PR TITLE
set authentication ticket on log-in and add user role authorization

### DIFF
--- a/CourseProject/Areas/Charges/Controllers/InvoicesController.cs
+++ b/CourseProject/Areas/Charges/Controllers/InvoicesController.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using CourseProject;
 using CourseProject.Models;
 using CourseProject.Common;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CourseProject.Areas.Charges.Controllers
 {
@@ -22,22 +23,17 @@ namespace CourseProject.Areas.Charges.Controllers
         }
 
         // GET: Charges/Invoices
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Index()
         {
-            if (Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
-            {
-                var databaseContext = _context.Invoices.Include(i => i.Resident);
-                return View(await databaseContext.ToListAsync());
-            }
-            return RedirectToAction("Forbidden", "Error");
+            var invoices = _context.Invoices.Include(i => i.Resident);
+            return View(await invoices.ToListAsync());
         }
 
         // GET: Charges/Invoices/Details/5
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Details(int? id)
         {
-            if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
-                return RedirectToAction("Forbidden", "Error");
-
             if (id == null)
             {
                 return NotFound();
@@ -55,20 +51,17 @@ namespace CourseProject.Areas.Charges.Controllers
         }
 
         // GET: Charges/Invoices/Create
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public IActionResult Create()
         {
-            if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
-                return RedirectToAction("Forbidden", "Error");
-
             ViewData["ResidentID"] = new SelectList(_context.Residents, "ResidentId", "ResidentId");
             return View();
         }
 
         // POST: Charges/Invoices/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Create([Bind("InvoiceID,ResidentID,Date,AmountDue,AmountPaid")] Invoice invoice)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
@@ -91,11 +84,9 @@ namespace CourseProject.Areas.Charges.Controllers
         }
 
         // GET: Charges/Invoices/Edit/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int? id)
         {
-            if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
-                return RedirectToAction("Forbidden", "Error");
-
             if (id == null)
             {
                 return NotFound();
@@ -111,10 +102,9 @@ namespace CourseProject.Areas.Charges.Controllers
         }
 
         // POST: Charges/Invoices/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit([Bind(Prefix = "InvoiceID")] int id, [Bind("InvoiceID,ResidentID,Date,AmountDue,AmountPaid")] Invoice invoice)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
@@ -156,6 +146,7 @@ namespace CourseProject.Areas.Charges.Controllers
         }
 
         // GET: Charges/Invoices/Delete/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Delete(int? id)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
@@ -180,6 +171,7 @@ namespace CourseProject.Areas.Charges.Controllers
         // POST: Charges/Invoices/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> DeleteConfirmed([Bind(Prefix = "InvoiceID")] int id)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.HOUSING_MANAGER, UserRole.EMPLOYEE))
@@ -191,7 +183,6 @@ namespace CourseProject.Areas.Charges.Controllers
             {
                 _context.Invoices.Remove(invoice);
             }
-
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));
         }

--- a/CourseProject/Areas/Employees/Controllers/EmployeesController.cs
+++ b/CourseProject/Areas/Employees/Controllers/EmployeesController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using CourseProject;
 using CourseProject.Models;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CourseProject.Areas.Employees.Controllers
 {
@@ -21,6 +22,7 @@ namespace CourseProject.Areas.Employees.Controllers
         }
 
         // GET: Employees/Employees
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Index()
         {
             if (HttpContext.Session.GetString("Username") == null)
@@ -32,6 +34,7 @@ namespace CourseProject.Areas.Employees.Controllers
         }
 
         // GET: Employees/Employees/Details/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -52,6 +55,7 @@ namespace CourseProject.Areas.Employees.Controllers
         }
 
         // GET: Employees/Employees/Create
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public IActionResult Create()
         {
             ViewBag.ManagerId = new SelectList(_context.Employees, "EmployeeId", "EmployeeId");
@@ -59,12 +63,10 @@ namespace CourseProject.Areas.Employees.Controllers
             return View();
         }
 
-
         // POST: Employees/Employees/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Create([Bind("EmployeeId,ManagerId,JobTitle,EmploymentType,PayRate,Availability,HoursWorked,Certifications,OrganizationId,Name,DetailsJson")] Employee employee, string Certifications)
         {
             if (!ModelState.IsValid)
@@ -83,8 +85,8 @@ namespace CourseProject.Areas.Employees.Controllers
             return View(employee);
         }
 
-
         // GET: Employees/Employees/Edit/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -97,8 +99,6 @@ namespace CourseProject.Areas.Employees.Controllers
             {
                 return NotFound();
             }
-
-            
 
             // Pass the data to the view
             ViewData["ManagerId"] = new SelectList(_context.Employees, "EmployeeId", "EmployeeId", employee.ManagerId);
@@ -115,6 +115,7 @@ namespace CourseProject.Areas.Employees.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int id, [Bind("EmployeeId,ManagerId,JobTitle,EmploymentType,PayRate,Availability,HoursWorked,Certifications,OrganizationId,Name,DetailsJson")] Employee employee)
         {
             //if (id != employee.EmployeeId)
@@ -148,6 +149,7 @@ namespace CourseProject.Areas.Employees.Controllers
         }
 
         // GET: Employees/Employees/Delete/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -169,6 +171,7 @@ namespace CourseProject.Areas.Employees.Controllers
 
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HR_MANAGER) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             var employee = await _context.Employees.FindAsync(id);
@@ -185,7 +188,6 @@ namespace CourseProject.Areas.Employees.Controllers
 
             return RedirectToAction(nameof(Index));
         }
-
 
         private bool EmployeeExists(int id)
         {

--- a/CourseProject/Areas/Housing/Controllers/AssetsController.cs
+++ b/CourseProject/Areas/Housing/Controllers/AssetsController.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CourseProject.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CourseProject.Areas.Housing.Controllers
 {
@@ -19,6 +21,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Assets
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Index()
         {
             var assets = await _context.Assets.ToListAsync();
@@ -51,9 +54,8 @@ namespace CourseProject.Areas.Housing.Controllers
             return View();
         }
 
-
-
         [HttpPost]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> ApproveRequest(int requestId)
         {
             var request = await _context.ResidentAssetRequests
@@ -79,6 +81,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         [HttpPost]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> DeclineRequest(int requestId)
         {
             var request = await _context.ResidentAssetRequests.FindAsync(requestId);
@@ -90,8 +93,8 @@ namespace CourseProject.Areas.Housing.Controllers
             return RedirectToAction("Index");
         }
 
-
         // GET: Assets/Assign/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Assign(int id)
         {
             var asset = await _context.Assets.FindAsync(id);
@@ -103,6 +106,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         [HttpPost]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Assign(int assetId, List<ResidentAssignmentViewModel> selectedResidents)
         {
             foreach (var item in selectedResidents)
@@ -128,10 +132,8 @@ namespace CourseProject.Areas.Housing.Controllers
             return RedirectToAction("Index");
         }
 
-
-
-
         // GET: Assets/Details/5
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -150,16 +152,16 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Assets/Create
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public IActionResult Create()
         {
             return View();
         }
 
         // POST: Assets/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Create([Bind("AssetID,Type,DetailsJson")] Asset asset)
         {
             if (ModelState.IsValid)
@@ -172,8 +174,8 @@ namespace CourseProject.Areas.Housing.Controllers
             return View(asset);
         }
 
-
         // GET: Assets/Edit/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -190,10 +192,9 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // POST: Assets/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int id, [Bind("AssetID,Type,DetailsJson")] Asset asset)
         {
             if (id != asset.AssetID)
@@ -225,6 +226,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Assets/Delete/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -245,6 +247,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // POST: Assets/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             var asset = await _context.Assets.FindAsync(id);
@@ -263,6 +266,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Assets/Available
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Available()
         {
             var availableAssets = await _context.Assets
@@ -272,6 +276,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Assets/Assigned
+        [Authorize(Roles = nameof(UserRole.RESIDENT) + "," + nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Assigned()
         {
             var assignedAssets = await _context.Assets
@@ -283,6 +288,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // POST: Assets/CancelRequest/5
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> CancelRequest(int id)
         {
             var asset = await _context.Assets.FindAsync(id);
@@ -297,6 +303,5 @@ namespace CourseProject.Areas.Housing.Controllers
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Assigned));
         }
-
     }
 }

--- a/CourseProject/Areas/Housing/Controllers/ResidentAssetsController.cs
+++ b/CourseProject/Areas/Housing/Controllers/ResidentAssetsController.cs
@@ -1,4 +1,5 @@
 ﻿using CourseProject.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,6 +16,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Housing/ResidentAssets
+        [Authorize(Roles = nameof(UserRole.RESIDENT))]
         public async Task<IActionResult> Index()
         {
             var availableAssets = await _context.Assets
@@ -28,6 +30,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Housing/ResidentAssets/Details/5
+        [Authorize(Roles = nameof(UserRole.RESIDENT))]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null) return NotFound();
@@ -40,6 +43,7 @@ namespace CourseProject.Areas.Housing.Controllers
 
         // POST: Housing/ResidentAssets/Request/5
         [HttpPost]
+        [Authorize(Roles = nameof(UserRole.RESIDENT))]
         public async Task<IActionResult> Request(int id)
         {
             var userName = User.Identity.Name;

--- a/CourseProject/Areas/Housing/Controllers/ResidentsController.cs
+++ b/CourseProject/Areas/Housing/Controllers/ResidentsController.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CourseProject.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +21,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Index()
         {
             var now = DateTime.Now;
@@ -56,6 +59,7 @@ namespace CourseProject.Areas.Housing.Controllers
 
 
         // GET: Residents/Details/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -74,6 +78,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents/Create
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public IActionResult Create()
         {
             return View();
@@ -84,6 +89,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Create([Bind("ResidentId,ServiceSubscriptionIds,Name,DetailsJson")] Resident resident)
         {
             if (ModelState.IsValid)
@@ -96,6 +102,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents/Edit/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -116,6 +123,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Edit(int id, [Bind("ResidentId,ServiceSubscriptionIds,Name,DetailsJson")] Resident resident)
         {
             if (id != resident.ResidentId)
@@ -147,6 +155,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents/Delete/5
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -164,6 +173,7 @@ namespace CourseProject.Areas.Housing.Controllers
             return View(resident);
         }
 
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> AssignedAssets(int id)
         {
             var resident = await _context.Residents.FindAsync(id);
@@ -186,6 +196,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // POST: Residents/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             var resident = await _context.Residents.FindAsync(id);
@@ -204,6 +215,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents/Current
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Current()
         {
             var currentRenters = await _context.Residents
@@ -213,6 +225,7 @@ namespace CourseProject.Areas.Housing.Controllers
         }
 
         // GET: Residents/Past
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> Past()
         {
             var pastRenters = await _context.Residents
@@ -224,6 +237,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // POST: Residents/UpdateOccupants/5
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> UpdateOccupants(int id, [FromForm] string newOccupantsJson)
         {
             var resident = await _context.Residents.FindAsync(id);
@@ -241,6 +255,7 @@ namespace CourseProject.Areas.Housing.Controllers
         // POST: Residents/MarkVacant/5
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.ADMIN) + "," + nameof(UserRole.HOUSING_MANAGER))]
         public async Task<IActionResult> MarkVacant(int id)
         {
             var resident = await _context.Residents.FindAsync(id);

--- a/CourseProject/Areas/Services/Controllers/ServicesController.cs
+++ b/CourseProject/Areas/Services/Controllers/ServicesController.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using CourseProject;
 using CourseProject.Models;
 using CourseProject.Common;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CourseProject.Areas.Services.Controllers
 {
@@ -21,7 +22,13 @@ namespace CourseProject.Areas.Services.Controllers
             _context = context;
         }
 
-        // GET: Services/Services        
+        // GET: Services/Services       
+        [Authorize(Roles = nameof(UserRole.NONE) + "," +
+                           nameof(UserRole.EMPLOYEE) + "," +
+                           nameof(UserRole.RESIDENT) + "," +
+                           nameof(UserRole.HR_MANAGER) + "," +
+                           nameof(UserRole.HOUSING_MANAGER) + "," +
+                           nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Index()
         {
             if (Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -32,6 +39,13 @@ namespace CourseProject.Areas.Services.Controllers
         }
 
         // GET: Services/Services/Details/5
+        // All roles can read
+        [Authorize(Roles = nameof(UserRole.NONE) + "," +
+                           nameof(UserRole.EMPLOYEE) + "," +
+                           nameof(UserRole.RESIDENT) + "," +
+                           nameof(UserRole.HR_MANAGER) + "," +
+                           nameof(UserRole.HOUSING_MANAGER) + "," +
+                           nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Details(int? id)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE)) 
@@ -53,6 +67,7 @@ namespace CourseProject.Areas.Services.Controllers
         }
 
         // GET: Services/Services/Create
+        [Authorize(Roles = nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public IActionResult Create()
         {            
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -66,6 +81,7 @@ namespace CourseProject.Areas.Services.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Create([Bind("ServiceID,Type,Rate,Requirements")] Service service)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -81,11 +97,11 @@ namespace CourseProject.Areas.Services.Controllers
         }
 
         // GET: Services/Services/Edit/5
+        [Authorize(Roles = nameof(UserRole.HR_MANAGER) + "," +
+                           nameof(UserRole.HOUSING_MANAGER) + "," +
+                           nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Edit(int? id)
         {
-            if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
-                return RedirectToAction("Forbidden", "Error");
-
             if (id == null)
             {
                 return NotFound();
@@ -104,6 +120,9 @@ namespace CourseProject.Areas.Services.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.HR_MANAGER) + "," +
+                           nameof(UserRole.HOUSING_MANAGER) + "," +
+                           nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Edit([Bind(Prefix = "ServiceID")] int id, [Bind("ServiceID,Type,Rate,Requirements")] Service service)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -138,6 +157,7 @@ namespace CourseProject.Areas.Services.Controllers
         }
 
         // GET: Services/Services/Delete/5
+        [Authorize(Roles = nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> Delete(int? id)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -161,6 +181,7 @@ namespace CourseProject.Areas.Services.Controllers
         // POST: Services/Services/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles = nameof(UserRole.HOUSING_MANAGER) + "," + nameof(UserRole.ADMIN))]
         public async Task<IActionResult> DeleteConfirmed([Bind(Prefix = "ServiceID")] int id)
         {
             if (!Util.HasAccess(HttpContext, UserRole.ADMIN, UserRole.SERVICE_MANAGER, UserRole.EMPLOYEE))
@@ -175,10 +196,9 @@ namespace CourseProject.Areas.Services.Controllers
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));
         }
-
         private bool ServiceExists(int id)
         {
             return _context.Services.Any(e => e.ServiceID == id);
-        }              
+        }        
     }
 }

--- a/CourseProject/Controllers/UsersController.cs
+++ b/CourseProject/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -8,6 +9,8 @@ using Microsoft.EntityFrameworkCore;
 using CourseProject;
 using CourseProject.Models;
 using Microsoft.AspNet.Identity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace MVCSampleApp.Controllers
 {
@@ -57,8 +60,21 @@ namespace MVCSampleApp.Controllers
                     user.Password = hasher.HashPassword(user.Password);
                     await _context.SaveChangesAsync();
                 }
+
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, user.Username),
+                    new Claim(ClaimTypes.Role, user.Role.ToString())
+                };
+
+                var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+                var principal = new ClaimsPrincipal(identity);
+
+                await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+
                 HttpContext.Session.SetString("Username", user.Username);
                 HttpContext.Session.SetString("Role", user.Role.ToString());
+
                 return RedirectToAction("Index", "Home");
             }
             ViewBag.Error = "Invalid login";
@@ -164,7 +180,7 @@ namespace MVCSampleApp.Controllers
                 }
                 return RedirectToAction(nameof(Index));
             }
-            return View(userView);
+            return View(user);
         }
 
         // GET: Users/Delete/5

--- a/CourseProject/Program.cs
+++ b/CourseProject/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using CourseProject;
 using CourseProject.Areas.Calendar.Models;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSession(options =>
@@ -12,6 +13,15 @@ builder.Services.AddSession(options =>
 });
 builder.Services.AddDbContext<DatabaseContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DBContext' not found.")));
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/Users/Login"; // Redirect here if not authenticated
+    });
+
+// Add authorization services
+builder.Services.AddAuthorization();
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
@@ -40,6 +50,7 @@ app.UseHttpsRedirection();
 app.UseRouting();
 
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapStaticAssets();

--- a/CourseProject/Program.cs
+++ b/CourseProject/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     .AddCookie(options =>
     {
         options.LoginPath = "/Users/Login"; // Redirect here if not authenticated
+        options.AccessDeniedPath = "/Error/403";
     });
 
 // Add authorization services


### PR DESCRIPTION
1. current log-in only stores user detail's in session and does not create authentication ticket, this fixes so that user signs in with authentication cookie used for role based authorization

2. add role based authorization based on role changes discussed on Monday with @MDoswell @jwl0724 and @Flanks365 

3. Currently if user is not authorized, it leads to page not found 404 but url is http://localhost:5072/Account/AccessDenied?ReturnUrl=%2FServices%2FDetails%2F1

![image](https://github.com/user-attachments/assets/b5b2e873-8f77-436f-adec-c200f7471f55)


Role authorization set based on: https://docs.google.com/document/d/1sLV3fHtluG6Jd2M0Hj8nzeP6R7NV1YJmN9Q443RYrok/edit?tab=t.0

Let me know if anything is missing or incorrect